### PR TITLE
WSLのデフォルトバージョンが1の場合に環境構築に失敗する問題を修正

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,7 +19,7 @@ If ($hash -ne $sha256sum) {
   Write-Error "Checksum failed. Please delete $tarball manually."
 }
 
-wsl.exe --import $Distro $InstallLocation $tarball
+wsl.exe --import $Distro $InstallLocation $tarball --version 2
 
 $scriptsdir = Join-Path $PSScriptRoot "scripts"
 Get-ChildItem $scriptsdir -Filter *.sh | Sort-Object -Property FullName | Foreach-Object {


### PR DESCRIPTION
デフォルトバージョンがWSL1の場合にWSL1が使用されて環境構築に失敗する問題があったので、WSL2が使用されるよう引数を加えました。